### PR TITLE
Added configuration to override with environment variables the docker images

### DIFF
--- a/Cmdlets/ExportWaykDenConfig.cs
+++ b/Cmdlets/ExportWaykDenConfig.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Management.Automation;
 using WaykDen.Controllers;
 using Newtonsoft.Json;
+using WaykDen.Models;
 
 namespace WaykDen.Cmdlets
 {
@@ -66,9 +67,9 @@ namespace WaykDen.Cmdlets
 
                     if(this.DockerScript)
                     {
-                        File.WriteAllText($"{this.ExportPath}{System.IO.Path.DirectorySeparatorChar}{DOCKER_SCRIPT_FILENAME}", denServicesController.CreateScript(this.ExportPath, false));
+                        File.WriteAllText($"{this.ExportPath}{System.IO.Path.DirectorySeparatorChar}{DOCKER_SCRIPT_FILENAME}", denServicesController.CreateScript(this.ExportPath, false, string.Equals(denServicesController.DenConfig.DenDockerConfigObject.Platform, "Linux") ? Platforms.Linux : Platforms.Windows));
                     }
-                    else File.WriteAllText($"{this.ExportPath}{System.IO.Path.DirectorySeparatorChar}{DOCKER_SCRIPT_FILENAME}", denServicesController.CreateScript(this.ExportPath, true));
+                    else File.WriteAllText($"{this.ExportPath}{System.IO.Path.DirectorySeparatorChar}{DOCKER_SCRIPT_FILENAME}", denServicesController.CreateScript(this.ExportPath, true, string.Equals(denServicesController.DenConfig.DenDockerConfigObject.Platform, "Linux") ? Platforms.Linux : Platforms.Windows));
                 }
             }
             catch(Exception e)

--- a/Cmdlets/StartWaykDen.cs
+++ b/Cmdlets/StartWaykDen.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Management.Automation;
 using WaykDen.Controllers;
+using WaykDen.Models;
 
 namespace WaykDen.Cmdlets
 {
@@ -40,6 +41,10 @@ namespace WaykDen.Cmdlets
                         }
                     }
                 }
+
+                Platforms p = string.Equals(this.denServicesController.DenConfig.DenDockerConfigObject.Platform, "Linux") ? Platforms.Linux : Platforms.Windows;
+                this.CheckOverrideDockerImages(p, this.denServicesController.DenConfig.DenImageConfigObject);
+
             }
             catch(Exception e)
             {
@@ -72,6 +77,51 @@ namespace WaykDen.Cmdlets
             {
                 this.mre.Set();
             }
+        }
+
+        private void CheckOverrideDockerImages(Platforms platform, DenImageConfigObject denImageConfig)
+        {
+            string originalLucid = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenLucidImage : DenImageConfigObject.WindowsDenLucidImage;
+            string originaMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
+            string originaPicky = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenPickyImage : DenImageConfigObject.WindowsDenPickyImage;
+            string originaRouter = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenRouterImage : DenImageConfigObject.WindowsDenRouterImage;
+            string originaServer = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenServerImage : DenImageConfigObject.WindowsDenServerImage;
+            string originaTraefik = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenTraefikImage : DenImageConfigObject.WindowsDenTraefikImage;
+            string originaJet = platform == Platforms.Linux ? DenImageConfigObject.LinuxDevolutionsJetImage : DenImageConfigObject.WindowsDevolutionsJetImage;
+
+            if (denImageConfig.DenLucidImage != originalLucid)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenLucidImage, originalLucid);
+            }
+            if (denImageConfig.DenMongoImage != originaMongo)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenMongoImage, originaMongo);
+            }
+            if (denImageConfig.DenPickyImage != originaPicky)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenPickyImage, originaPicky);
+            }
+            if (denImageConfig.DenRouterImage != originaRouter)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenRouterImage, originaRouter);
+            }
+            if (denImageConfig.DenServerImage != originaServer)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenServerImage, originaServer);
+            }
+            if (denImageConfig.DenTraefikImage != originaTraefik)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DenTraefikImage, originaTraefik);
+            }
+            if (denImageConfig.DevolutionsJetImage != originaJet)
+            {
+                ShowDockerImageIsOverride(denImageConfig.DevolutionsJetImage, originaJet);
+            }
+        }
+
+        private void ShowDockerImageIsOverride(string stringOverride, string original)
+        {
+            this.WriteWarning($@"The original docker image: '{original}' is overridden by '{stringOverride}'");
         }
     }
 }

--- a/Cmdlets/StartWaykDen.cs
+++ b/Cmdlets/StartWaykDen.cs
@@ -82,40 +82,40 @@ namespace WaykDen.Cmdlets
         private void CheckOverrideDockerImages(Platforms platform, DenImageConfigObject denImageConfig)
         {
             string originalLucid = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenLucidImage : DenImageConfigObject.WindowsDenLucidImage;
-            string originaMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
-            string originaPicky = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenPickyImage : DenImageConfigObject.WindowsDenPickyImage;
-            string originaRouter = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenRouterImage : DenImageConfigObject.WindowsDenRouterImage;
-            string originaServer = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenServerImage : DenImageConfigObject.WindowsDenServerImage;
-            string originaTraefik = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenTraefikImage : DenImageConfigObject.WindowsDenTraefikImage;
-            string originaJet = platform == Platforms.Linux ? DenImageConfigObject.LinuxDevolutionsJetImage : DenImageConfigObject.WindowsDevolutionsJetImage;
+            string originalMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
+            string originalPicky = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenPickyImage : DenImageConfigObject.WindowsDenPickyImage;
+            string originalRouter = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenRouterImage : DenImageConfigObject.WindowsDenRouterImage;
+            string originalServer = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenServerImage : DenImageConfigObject.WindowsDenServerImage;
+            string originalTraefik = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenTraefikImage : DenImageConfigObject.WindowsDenTraefikImage;
+            string originalJet = platform == Platforms.Linux ? DenImageConfigObject.LinuxDevolutionsJetImage : DenImageConfigObject.WindowsDevolutionsJetImage;
 
             if (denImageConfig.DenLucidImage != originalLucid)
             {
                 ShowDockerImageIsOverride(denImageConfig.DenLucidImage, originalLucid);
             }
-            if (denImageConfig.DenMongoImage != originaMongo)
+            if (denImageConfig.DenMongoImage != originalMongo)
             {
-                ShowDockerImageIsOverride(denImageConfig.DenMongoImage, originaMongo);
+                ShowDockerImageIsOverride(denImageConfig.DenMongoImage, originalMongo);
             }
-            if (denImageConfig.DenPickyImage != originaPicky)
+            if (denImageConfig.DenPickyImage != originalPicky)
             {
-                ShowDockerImageIsOverride(denImageConfig.DenPickyImage, originaPicky);
+                ShowDockerImageIsOverride(denImageConfig.DenPickyImage, originalPicky);
             }
-            if (denImageConfig.DenRouterImage != originaRouter)
+            if (denImageConfig.DenRouterImage != originalRouter)
             {
-                ShowDockerImageIsOverride(denImageConfig.DenRouterImage, originaRouter);
+                ShowDockerImageIsOverride(denImageConfig.DenRouterImage, originalRouter);
             }
-            if (denImageConfig.DenServerImage != originaServer)
+            if (denImageConfig.DenServerImage != originalServer)
             {
-                ShowDockerImageIsOverride(denImageConfig.DenServerImage, originaServer);
+                ShowDockerImageIsOverride(denImageConfig.DenServerImage, originalServer);
             }
-            if (denImageConfig.DenTraefikImage != originaTraefik)
+            if (denImageConfig.DenTraefikImage != originalTraefik)
             {
-                ShowDockerImageIsOverride(denImageConfig.DenTraefikImage, originaTraefik);
+                ShowDockerImageIsOverride(denImageConfig.DenTraefikImage, originalTraefik);
             }
-            if (denImageConfig.DevolutionsJetImage != originaJet)
+            if (denImageConfig.DevolutionsJetImage != originalJet)
             {
-                ShowDockerImageIsOverride(denImageConfig.DevolutionsJetImage, originaJet);
+                ShowDockerImageIsOverride(denImageConfig.DevolutionsJetImage, originalJet);
             }
         }
 

--- a/Controllers/DenServicesController.cs
+++ b/Controllers/DenServicesController.cs
@@ -78,7 +78,7 @@ namespace WaykDen.Controllers
 
             Platforms p = string.Equals(this.DenConfig.DenDockerConfigObject.Platform, "Linux") ? Platforms.Linux : Platforms.Windows;
             this.DenConfig.DenImageConfigObject = new DenImageConfigObject(p);
-        
+                            
             this.DockerClient = new DockerClientConfiguration(new Uri(this.DenConfig.DenDockerConfigObject.DockerClientUri)).CreateClient();
         }
 
@@ -417,7 +417,7 @@ namespace WaykDen.Controllers
                         this.WriteError(new Exception("Error starting Traefik service. Make sure External URL is well configured."));
                     }
                 }
-                
+
                 return started;
             }
             catch(Exception e)
@@ -459,10 +459,10 @@ namespace WaykDen.Controllers
             return ExportDenConfigUtils.CreateTraefikToml(new DenTraefikService(this));
         }
 
-        public string CreateScript(string exportPath, bool podman)
+        public string CreateScript(string exportPath, bool podman, Platforms platform)
         {
             this.Path = exportPath;
-            string config = this.DenConfig.ConvertToPwshParameters();
+            string config = this.DenConfig.ConvertToPwshParameters(platform);
             return ExportDenConfigUtils.CreateScript(podman, this.GetDenServicesConfig(), exportPath, config);
         }
 

--- a/Models/DenConfig.cs
+++ b/Models/DenConfig.cs
@@ -17,7 +17,7 @@ namespace WaykDen.Models
         public DenImageConfigObject DenImageConfigObject {get; set;}
         public DenDockerConfigObject DenDockerConfigObject {get; set;}
 
-        public string ConvertToPwshParameters()
+        public string ConvertToPwshParameters(Platforms platform)
         {
             StringBuilder sb = new StringBuilder();
             bool syslog = false;
@@ -39,13 +39,29 @@ namespace WaykDen.Models
                     }
                 }
 
-                if(!string.IsNullOrEmpty(this.DenDockerConfigObject.SyslogServer) && !syslog)
+                if (!string.IsNullOrEmpty(this.DenDockerConfigObject.SyslogServer) && !syslog)
                 {
                     syslog = true;    
                 }
             }
 
-            if(syslog)
+            string DenOriginalImageLucid = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenLucidImage : DenImageConfigObject.WindowsDenLucidImage;
+            string DenOriginalImagMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
+            string DenOriginalImagePicky = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenPickyImage : DenImageConfigObject.WindowsDenPickyImage;
+            string DenOriginalImageRouter = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenRouterImage : DenImageConfigObject.WindowsDenRouterImage;
+            string DenOriginalImageServer = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenServerImage : DenImageConfigObject.WindowsDenServerImage;
+            string DenOriginalImageTraefik = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenTraefikImage : DenImageConfigObject.WindowsDenTraefikImage;
+            string DenOriginalImageJetImage = platform == Platforms.Linux ? DenImageConfigObject.LinuxDevolutionsJetImage : DenImageConfigObject.WindowsDevolutionsJetImage;
+
+            sb.AppendLine($"$DenOriginalImageLucid = \'{DenOriginalImageLucid}\'");
+            sb.AppendLine($"$DenOriginalImagMongo = \'{DenOriginalImagMongo}\'");
+            sb.AppendLine($"$DenOriginalImagePicky = \'{DenOriginalImagePicky}\'");
+            sb.AppendLine($"$DenOriginalImageRouter = \'{DenOriginalImageRouter}\'");
+            sb.AppendLine($"$DenOriginalImageServer = \'{DenOriginalImageServer}\'");
+            sb.AppendLine($"$DenOriginalImageTraefik = \'{DenOriginalImageTraefik}\'");
+            sb.AppendLine($"$DenOriginalImageJetImage = \'{DenOriginalImageJetImage}\'");
+
+            if (syslog)
             {
                 sb.AppendLine("$logDriver = \'syslog\'");
                 sb.AppendLine($"$syslogOptions = @(\'syslog-address={this.DenDockerConfigObject.SyslogServer}\',\'syslog-format=rfc5424\',\'syslog-facility=daemon\')");

--- a/Models/DenConfig.cs
+++ b/Models/DenConfig.cs
@@ -46,7 +46,7 @@ namespace WaykDen.Models
             }
 
             string DenOriginalImageLucid = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenLucidImage : DenImageConfigObject.WindowsDenLucidImage;
-            string DenOriginalImagMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
+            string DenOriginalImageMongo = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenMongoImage : DenImageConfigObject.WindowsDenMongoImage;
             string DenOriginalImagePicky = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenPickyImage : DenImageConfigObject.WindowsDenPickyImage;
             string DenOriginalImageRouter = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenRouterImage : DenImageConfigObject.WindowsDenRouterImage;
             string DenOriginalImageServer = platform == Platforms.Linux ? DenImageConfigObject.LinuxDenServerImage : DenImageConfigObject.WindowsDenServerImage;
@@ -54,7 +54,7 @@ namespace WaykDen.Models
             string DenOriginalImageJetImage = platform == Platforms.Linux ? DenImageConfigObject.LinuxDevolutionsJetImage : DenImageConfigObject.WindowsDevolutionsJetImage;
 
             sb.AppendLine($"$DenOriginalImageLucid = \'{DenOriginalImageLucid}\'");
-            sb.AppendLine($"$DenOriginalImagMongo = \'{DenOriginalImagMongo}\'");
+            sb.AppendLine($"$DenOriginalImageMongo = \'{DenOriginalImageMongo}\'");
             sb.AppendLine($"$DenOriginalImagePicky = \'{DenOriginalImagePicky}\'");
             sb.AppendLine($"$DenOriginalImageRouter = \'{DenOriginalImageRouter}\'");
             sb.AppendLine($"$DenOriginalImageServer = \'{DenOriginalImageServer}\'");

--- a/Models/DenConfigObjects.cs
+++ b/Models/DenConfigObjects.cs
@@ -95,20 +95,22 @@ namespace WaykDen.Models
         private const string SERVER = "server";
         private const string TRAEFIK = "traefik";
         private const string JET = "jet";
-        private const string LinuxDenMongoImage = "library/mongo:4.1-bionic";
-        private const string LinuxDenLucidImage = "devolutions/den-lucid:3.5.3-buster";
-        private const string LinuxDenPickyImage = "devolutions/picky:3.0.0-buster";
-        private const string LinuxDenRouterImage = "devolutions/den-router:0.5.0-buster";
-        private const string LinuxDenServerImage = "devolutions/den-server:1.5.0-buster";
-        private const string LinuxDenTraefikImage = "library/traefik:1.7";
-        private const string LinuxDevolutionsJetImage = "devolutions/devolutions-jet:0.4.0-stretch";
-        private const string WindowsDenMongoImage = "library/mongo:4.2.0-rc3-windowsservercore-ltsc2016";
-        private const string WindowsDenLucidImage = "devolutions/den-lucid:3.3.3-servercore-ltsc2019";
-        private const string WindowsDenPickyImage = "devolutions/picky:3.0.0-servercore-ltsc2019";
-        private const string WindowsDenRouterImage = "devolutions/den-router:0.5.0-servercore-ltsc2019";
-        private const string WindowsDenServerImage = "devolutions/den-server:1.5.0-servercore-ltsc2019";
-        private const string WindowsDenTraefikImage = "sixeyed/traefik:v1.7.8-windowsservercore-ltsc2019";
-        private const string WindowsDevolutionsJetImage = "devolutions/devolutions-jet:0.4.0-servercore-ltsc2019";
+
+        public const string LinuxDenMongoImage = "library/mongo:4.1-bionic";
+        public const string LinuxDenLucidImage = "devolutions/den-lucid:3.5.3-buster";
+        public const string LinuxDenPickyImage = "devolutions/picky:3.0.0-buster";
+        public const string LinuxDenRouterImage = "devolutions/den-router:0.5.0-buster";
+        public const string LinuxDenServerImage = "devolutions/den-server:1.5.0-buster";
+        public const string LinuxDenTraefikImage = "library/traefik:1.7";
+        public const string LinuxDevolutionsJetImage = "devolutions/devolutions-jet:0.4.0-stretch";
+        public const string WindowsDenMongoImage = "library/mongo:4.2.0-rc3-windowsservercore-ltsc2016";
+        public const string WindowsDenLucidImage = "devolutions/den-lucid:3.3.3-servercore-ltsc2019";
+        public const string WindowsDenPickyImage = "devolutions/picky:3.0.0-servercore-ltsc2019";
+        public const string WindowsDenRouterImage = "devolutions/den-router:0.5.0-servercore-ltsc2019";
+        public const string WindowsDenServerImage = "devolutions/den-server:1.5.0-servercore-ltsc2019";
+        public const string WindowsDenTraefikImage = "sixeyed/traefik:v1.7.8-windowsservercore-ltsc2019";
+        public const string WindowsDevolutionsJetImage = "devolutions/devolutions-jet:0.4.0-servercore-ltsc2019";
+
         [JsonIgnore]
         public int Id {get; set;}
         public string DenMongoImage {get; set;}
@@ -150,13 +152,43 @@ namespace WaykDen.Models
         {
             if(this.images.TryGetValue(platform, out Dictionary<string, string> images))
             {
-                this.DenMongoImage = images.TryGetValue(MONGO, out string mongo) ? mongo : throw new Exception("Could not find image for Mongodb");
-                this.DenPickyImage = images.TryGetValue(PICKY, out string picky) ? picky : throw new Exception("Could not find image for Den-picky");
-                this.DenLucidImage = images.TryGetValue(LUCID, out string lucid) ? lucid : throw new Exception("Could not find image for Den-lucid");
-                this.DenRouterImage = images.TryGetValue(ROUTER, out string router) ? router : throw new Exception("Could not find image for Den-router");
-                this.DenServerImage = images.TryGetValue(SERVER, out string server) ? server : throw new Exception("Could not find image for Den-server");
-                this.DenTraefikImage = images.TryGetValue(TRAEFIK, out string traefik) ? traefik : throw new Exception("Could not find image for Traefik");
-                this.DevolutionsJetImage = images.TryGetValue(JET, out string jet) ? jet : throw new Exception("Could not find image for DevolutionsJet");
+                string mongoEnvironement = Environment.GetEnvironmentVariable("DEN_MONGO_IMAGE");
+                string pickyEnvironement = Environment.GetEnvironmentVariable("DEN_PICKY_IMAGE");
+                string lucidEnvironement = Environment.GetEnvironmentVariable("DEN_LUCID_IMAGE");
+                string routeurEnvironement = Environment.GetEnvironmentVariable("DEN_ROUTER_IMAGE");
+                string serverEnvironement = Environment.GetEnvironmentVariable("DEN_SERVER_IMAGE");
+                string traefikEnvironement = Environment.GetEnvironmentVariable("DEN_TRAEFIK_IMAGE");
+                string jetEnvironement = Environment.GetEnvironmentVariable("DEN_JET_IMAGE");
+
+                if (!string.IsNullOrEmpty(mongoEnvironement)){
+                    this.DenMongoImage = mongoEnvironement;
+                }else{
+                    this.DenMongoImage = images.TryGetValue(MONGO, out string mongo) ? mongo : throw new Exception("Could not find image for Mongodb");
+                }if (!string.IsNullOrEmpty(pickyEnvironement)){
+                    this.DenPickyImage = pickyEnvironement;
+                }else{
+                    this.DenPickyImage = images.TryGetValue(PICKY, out string picky) ? picky : throw new Exception("Could not find image for Den-picky");
+                }if (!string.IsNullOrEmpty(lucidEnvironement)){
+                    this.DenLucidImage = lucidEnvironement;
+                }else {
+                    this.DenLucidImage = images.TryGetValue(LUCID, out string lucid) ? lucid : throw new Exception("Could not find image for Den-lucid");
+                }if (!string.IsNullOrEmpty(routeurEnvironement)) {
+                    this.DenRouterImage = routeurEnvironement;
+                }else{
+                    this.DenRouterImage = images.TryGetValue(ROUTER, out string router) ? router : throw new Exception("Could not find image for Den-router");
+                }if (!string.IsNullOrEmpty(serverEnvironement)){
+                    this.DenServerImage = serverEnvironement;
+                }else {
+                    this.DenServerImage = images.TryGetValue(SERVER, out string server) ? server : throw new Exception("Could not find image for Den-server");
+                }if (!string.IsNullOrEmpty(traefikEnvironement)){
+                    this.DenTraefikImage = traefikEnvironement;
+                }else{
+                    this.DenTraefikImage = images.TryGetValue(TRAEFIK, out string traefik) ? traefik : throw new Exception("Could not find image for Traefik");
+                }if (!string.IsNullOrEmpty(jetEnvironement)){
+                    this.DevolutionsJetImage = jetEnvironement;
+                }else{
+                    this.DevolutionsJetImage = images.TryGetValue(JET, out string jet) ? jet : throw new Exception("Could not find image for DevolutionsJet");
+                }
             }
         }
     }

--- a/Models/DenConfigObjects.cs
+++ b/Models/DenConfigObjects.cs
@@ -152,40 +152,40 @@ namespace WaykDen.Models
         {
             if(this.images.TryGetValue(platform, out Dictionary<string, string> images))
             {
-                string mongoEnvironement = Environment.GetEnvironmentVariable("DEN_MONGO_IMAGE");
-                string pickyEnvironement = Environment.GetEnvironmentVariable("DEN_PICKY_IMAGE");
-                string lucidEnvironement = Environment.GetEnvironmentVariable("DEN_LUCID_IMAGE");
-                string routeurEnvironement = Environment.GetEnvironmentVariable("DEN_ROUTER_IMAGE");
-                string serverEnvironement = Environment.GetEnvironmentVariable("DEN_SERVER_IMAGE");
-                string traefikEnvironement = Environment.GetEnvironmentVariable("DEN_TRAEFIK_IMAGE");
-                string jetEnvironement = Environment.GetEnvironmentVariable("DEN_JET_IMAGE");
+                string mongoEnvironment = Environment.GetEnvironmentVariable("DEN_MONGO_IMAGE");
+                string pickyEnvironment = Environment.GetEnvironmentVariable("DEN_PICKY_IMAGE");
+                string lucidEnvironment = Environment.GetEnvironmentVariable("DEN_LUCID_IMAGE");
+                string routeurEnvironment = Environment.GetEnvironmentVariable("DEN_ROUTER_IMAGE");
+                string serverEnvironment = Environment.GetEnvironmentVariable("DEN_SERVER_IMAGE");
+                string traefikEnvironment = Environment.GetEnvironmentVariable("DEN_TRAEFIK_IMAGE");
+                string jetEnvironment = Environment.GetEnvironmentVariable("DEN_JET_IMAGE");
 
-                if (!string.IsNullOrEmpty(mongoEnvironement)){
-                    this.DenMongoImage = mongoEnvironement;
+                if (!string.IsNullOrEmpty(mongoEnvironment)){
+                    this.DenMongoImage = mongoEnvironment;
                 }else{
                     this.DenMongoImage = images.TryGetValue(MONGO, out string mongo) ? mongo : throw new Exception("Could not find image for Mongodb");
-                }if (!string.IsNullOrEmpty(pickyEnvironement)){
-                    this.DenPickyImage = pickyEnvironement;
+                }if (!string.IsNullOrEmpty(pickyEnvironment)){
+                    this.DenPickyImage = pickyEnvironment;
                 }else{
                     this.DenPickyImage = images.TryGetValue(PICKY, out string picky) ? picky : throw new Exception("Could not find image for Den-picky");
-                }if (!string.IsNullOrEmpty(lucidEnvironement)){
-                    this.DenLucidImage = lucidEnvironement;
+                }if (!string.IsNullOrEmpty(lucidEnvironment)){
+                    this.DenLucidImage = lucidEnvironment;
                 }else {
                     this.DenLucidImage = images.TryGetValue(LUCID, out string lucid) ? lucid : throw new Exception("Could not find image for Den-lucid");
-                }if (!string.IsNullOrEmpty(routeurEnvironement)) {
-                    this.DenRouterImage = routeurEnvironement;
+                }if (!string.IsNullOrEmpty(routeurEnvironment)) {
+                    this.DenRouterImage = routeurEnvironment;
                 }else{
                     this.DenRouterImage = images.TryGetValue(ROUTER, out string router) ? router : throw new Exception("Could not find image for Den-router");
-                }if (!string.IsNullOrEmpty(serverEnvironement)){
-                    this.DenServerImage = serverEnvironement;
+                }if (!string.IsNullOrEmpty(serverEnvironment)){
+                    this.DenServerImage = serverEnvironment;
                 }else {
                     this.DenServerImage = images.TryGetValue(SERVER, out string server) ? server : throw new Exception("Could not find image for Den-server");
-                }if (!string.IsNullOrEmpty(traefikEnvironement)){
-                    this.DenTraefikImage = traefikEnvironement;
+                }if (!string.IsNullOrEmpty(traefikEnvironment)){
+                    this.DenTraefikImage = traefikEnvironment;
                 }else{
                     this.DenTraefikImage = images.TryGetValue(TRAEFIK, out string traefik) ? traefik : throw new Exception("Could not find image for Traefik");
-                }if (!string.IsNullOrEmpty(jetEnvironement)){
-                    this.DevolutionsJetImage = jetEnvironement;
+                }if (!string.IsNullOrEmpty(jetEnvironment)){
+                    this.DevolutionsJetImage = jetEnvironment;
                 }else{
                     this.DevolutionsJetImage = images.TryGetValue(JET, out string jet) ? jet : throw new Exception("Could not find image for DevolutionsJet");
                 }

--- a/Models/DenConfigObjects.cs
+++ b/Models/DenConfigObjects.cs
@@ -97,7 +97,7 @@ namespace WaykDen.Models
         private const string JET = "jet";
 
         public const string LinuxDenMongoImage = "library/mongo:4.1-bionic";
-        public const string LinuxDenLucidImage = "devolutions/den-lucid:3.5.3-buster";
+        public const string LinuxDenLucidImage = "devolutions/den-lucid:3.3.3-buster";
         public const string LinuxDenPickyImage = "devolutions/picky:3.0.0-buster";
         public const string LinuxDenRouterImage = "devolutions/den-router:0.5.0-buster";
         public const string LinuxDenServerImage = "devolutions/den-server:1.5.0-buster";

--- a/Utils/ExportDenConfigUtils.cs
+++ b/Utils/ExportDenConfigUtils.cs
@@ -603,8 +603,8 @@ param(
         if(!($DenImageDenLucidImage -eq $DenOriginalImageLucid)){{
             ShowDockerImageIsOverride $DenImageDenLucidImage $DenOriginalImageLucid
         }}
-        if(!($DenImageDenMongoImage -eq $DenOriginalImagMongo)){{
-            ShowDockerImageIsOverride $DenImageDenMongoImage $DenOriginalImagMongo
+        if(!($DenImageDenMongoImage -eq $DenOriginalImageMongo)){{
+            ShowDockerImageIsOverride $DenImageDenMongoImage $DenOriginalImageMongo
         }}
         if(!($DenImageDenPickyImage -eq $DenOriginalImagePicky)){{
             ShowDockerImageIsOverride $DenImageDenPickyImage $DenOriginalImagePicky


### PR DESCRIPTION
- Show warning if you override an docker image
- Configuration to override with environment variables the docker images
Example of environment variables : 
$Env:DEN_MONGO_IMAGE = "library/mongo:4.1-bionic"
$Env:DEN_PICKY_IMAGE = "devolutions/picky:3.0.0-buster"
$Env:DEN_LUCID_IMAGE = "devolutions/den-lucid:3.5.3-buster-dev"
$Env:DEN_ROUTER_IMAGE = "devolutions/den-router:0.5.0-buster"
$Env:DEN_SERVER_IMAGE = "devolutions/den-server:1.5.0-buster-dev"
$Env:DEN_TRAEFIK_IMAGE = "library/traefik:1.7"
$Env:DEN_JET_IMAGE = "devolutions/devolutions-jet:0.4.0-stretch"