### PR TITLE
wayk-1757 - Support multiple den-server OnPrem

### DIFF
--- a/WaykDen/Tools/StartNatsRedis.ps1
+++ b/WaykDen/Tools/StartNatsRedis.ps1
@@ -3,14 +3,14 @@
 # OR
 # Set-WaykDenConfig -NatsUsername user -NatsPassword secret -RedisPassword secret123
 # To show the info: Get-WaykDenConfig
-# en then ./StartNatsRedis.ps1 -NatsUsername user -NatsPassword secret -RedisPassword secret123
+# and then ./StartNatsRedis.ps1 -NatsUsername user -NatsPassword secret -RedisPassword secret123
 
 param(
-    [Parameter(Mandatory=$false, HelpMessage="Nats Username")]
+    [Parameter(Mandatory=$true, HelpMessage="Nats Username")]
     [string] $NatsUsername,
-    [Parameter(Mandatory=$false, HelpMessage="Nats Password")]
+    [Parameter(Mandatory=$true, HelpMessage="Nats Password")]
     [string] $NatsPassword,
-    [Parameter(Mandatory=$false, HelpMessage="Redis Password")]
+    [Parameter(Mandatory=$true, HelpMessage="Redis Password")]
     [string] $RedisPassword
 )
 
@@ -31,5 +31,13 @@ function Start-Redis(
     & docker run -d --network=den-network -p 6379:6379 --name den-redis redis redis-server --requirepass $RedisPassword
 }
 
+function Create-Network{
+    $network = $(docker network ls -qf “name=den-network”)
+    if(!($network)){
+        docker network create den-network
+    }
+}  
+
+Create-Network
 Start-Nats $NatsUsername $NatsPassword
 Start-Redis $RedisPassword

--- a/WaykDen/src/Cmdlets/StartWaykDen.cs
+++ b/WaykDen/src/Cmdlets/StartWaykDen.cs
@@ -12,9 +12,6 @@ namespace WaykDen.Cmdlets
         [Parameter(Mandatory = false)]
         public int InstanceCount { get; set; } = 1;
 
-        [Parameter(Mandatory = false)]
-        public string ClientID { get; set; }
-
         private Exception error;
         private DenServicesController denServicesController;
         private bool started = false;
@@ -25,7 +22,7 @@ namespace WaykDen.Cmdlets
                 this.denServicesController = new DenServicesController(this.Path, this.DenConfigController);
                 this.denServicesController.OnLog += this.OnLog;
                 this.denServicesController.OnError += this.OnError;
-                Task<bool> start = this.denServicesController.StartWaykDen(this.InstanceCount, ClientID);
+                Task<bool> start = this.denServicesController.StartWaykDen(this.InstanceCount);
                 this.started = true;
 
                 while(!start.IsCompleted && !start.IsCanceled)

--- a/WaykDen/src/Controllers/DenServicesController.cs
+++ b/WaykDen/src/Controllers/DenServicesController.cs
@@ -113,9 +113,9 @@ namespace WaykDen.Controllers
             return await this.StartService(lucid);
         }
 
-        private async Task<bool> StartDenServer(int instanceCount = 1, string clientID = null)
+        private async Task<bool> StartDenServer(bool multipleInstance = false, int instanceId = 1)
         {
-            DenServerService server = new DenServerService(this, instanceCount, clientID);
+            DenServerService server = new DenServerService(this, multipleInstance, instanceId);
             return await this.StartService(server);
         }
 
@@ -354,7 +354,7 @@ namespace WaykDen.Controllers
             return networkIds;
         }
 
-        public async Task<bool> StartWaykDen(int instanceCount = 1, string clientID = null)
+        public async Task<bool> StartWaykDen(int instanceCount = 1)
         {
             try
             {
@@ -408,7 +408,7 @@ namespace WaykDen.Controllers
                 int count = 1;
                 while (count != instanceCount + 1)
                 {
-                    started = started ? await this.StartDenServer(count, clientID) : false;
+                    started = started ? await this.StartDenServer(instanceCount > 1, count) : false;
                     count++;
                 }
 

--- a/WaykDen/src/Models/DenConfigObjects.cs
+++ b/WaykDen/src/Models/DenConfigObjects.cs
@@ -100,7 +100,7 @@ namespace WaykDen.Models
         public const string WindowsDenMongoImage = "devolutions/mongo:4.0.12-windowsservercore-ltsc2019";
         public const string WindowsDenLucidImage = "devolutions/den-lucid:3.6.5-servercore-ltsc2019";
         public const string WindowsDenPickyImage = "devolutions/picky:4.0.0-servercore-ltsc2019";
-        public const string WindowsDenServerImage = "devolutions/den-server:1.8.0-servercore-ltsc2019";
+        public const string WindowsDenServerImage = "devolutions/den-server:1.9.0-servercore-ltsc2019-dev";
         public const string WindowsDenTraefikImage = "sixeyed/traefik:v1.7.8-windowsservercore-ltsc2019";
         public const string WindowsDevolutionsJetImage = "devolutions/devolutions-jet:0.6.0-servercore-ltsc2019";
         [JsonIgnore]

--- a/WaykDen/src/Models/DenConfigObjects.cs
+++ b/WaykDen/src/Models/DenConfigObjects.cs
@@ -94,7 +94,7 @@ namespace WaykDen.Models
         public const string LinuxDenMongoImage = "library/mongo:4.1-bionic";
         public const string LinuxDenLucidImage = "devolutions/den-lucid:3.6.5-buster";
         public const string LinuxDenPickyImage = "devolutions/picky:4.0.0-buster";
-        public const string LinuxDenServerImage = "devolutions/den-server:1.8.0-buster";
+        public const string LinuxDenServerImage = "devolutions/den-server:1.9.0-buster-dev";
         public const string LinuxDenTraefikImage = "library/traefik:1.7";
         public const string LinuxDevolutionsJetImage = "devolutions/devolutions-jet:0.6.0";
         public const string WindowsDenMongoImage = "devolutions/mongo:4.0.12-windowsservercore-ltsc2019";


### PR DESCRIPTION
We start wayk-den OnPrem with multiple den-server.
- The mode is always onPrem
- No need to specify the client_id for lucid
- Nats/Redis will be used if we start with more than 1 instance