### PR TITLE
2020.2.3 preparation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,13 @@
 
 This document provides a list of notable changes introduced in Wayk Den by release.
 
+== 2020.2.3 (2020-07-30)
+  * Add Wayk Den enrolment token support
+  * Allow Active Directory user to open a session with his credentials
+  * Add alias support
+  ** Auto-alias with machine name for all servers
+  ** Auto-alias with fully qualified name (machine_name.domain.loc) for Windows servers
+
 == 2020.2.2 (2020-07-06)
   * Fix User-Agent parsing
   * Fix an issue where an old client moving to 2020.2.0 had its Den ID reset

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,12 +2,11 @@
 
 This document provides a list of notable changes introduced in Wayk Den by release.
 
-== 2020.2.3 (2020-07-30)
-  * Add Wayk Den enrolment token support
-  * Allow Active Directory user to open a session with his credentials
-  * Add alias support
-  ** Auto-alias with machine name for all servers
-  ** Auto-alias with fully qualified name (machine_name.domain.loc) for Windows servers
+== 2020.2.3 (2020-08-03)
+  * Add initial Wayk Den enrollment token for Wayk Now automation
+  * Add automatic machine name alias usable as target id for all servers
+  * Add automatic fully qualified DNS name alias for domain-joined machines
+  * Allow SRD connections with matching Active Directory user on target machine
 
 == 2020.2.2 (2020-07-06)
   * Fix User-Agent parsing

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -14,7 +14,7 @@ function Get-WaykDenImage
 
     $LucidVersion = '3.7.2'
     $PickyVersion = '4.5.0'
-    $ServerVersion = '2.6.0'
+    $ServerVersion = '2.7.0'
 
     $MongoVersion = '4.2'
     $TraefikVersion = '1.7'

--- a/WaykDen/WaykDen.psd1
+++ b/WaykDen/WaykDen.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykDen.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.2.2'
+    ModuleVersion = '2020.2.3'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
Préparation de la version 2020.2.3.
Ne pas merger tout de suite, la version officielle de den-server n'est pas encore dispo.