### PR TITLE
Add "simple jet" option, enabled by default

### DIFF
--- a/WaykDen/Private/CaseHelper.ps1
+++ b/WaykDen/Private/CaseHelper.ps1
@@ -47,3 +47,26 @@ function ConvertTo-SnakeCaseObject
 
     return $snake_obj
 }
+
+function Remove-DefaultProperties
+{
+    param(
+        [Parameter(Position=0)]
+        $DirtyObject,
+        [Parameter(Position=1)]
+        $DefaultObject
+    )
+
+    $CleanObject = New-Object -TypeName 'PSObject'
+
+    $DirtyObject.PSObject.Properties | ForEach-Object {
+        $name = $_.Name
+        $value = $_.Value
+
+        if (-Not ($DefaultObject.($name) -eq $value)) {
+            $CleanObject | Add-Member -MemberType NoteProperty -Name $name -Value $value
+        }
+    }
+
+    return $CleanObject
+}

--- a/WaykDen/Private/TraefikHelper.ps1
+++ b/WaykDen/Private/TraefikHelper.ps1
@@ -8,7 +8,8 @@ function New-TraefikToml
         [string] $LucidUrl,
         [string] $PickyUrl,
         [string] $DenRouterUrl,
-        [string] $DenServerUrl
+        [string] $DenServerUrl,
+        [bool] $JetExternal
     )
 
     $url = [System.Uri]::new($ListenerUrl)

--- a/WaykDen/Private/TraefikHelper.ps1
+++ b/WaykDen/Private/TraefikHelper.ps1
@@ -103,6 +103,17 @@ logLevel = "INFO"
     entrypoints = ["${TraefikEntrypoint}"]
 '
 
+    if (-Not $JetExternal) {
+        $templates += '
+    [frontends.jet-relay]
+    passHostHeader = true
+    backend = "jet-relay"
+    entrypoints = ["${TraefikEntrypoint}"]
+        [frontends.jet-relay.routes.jet-relay]
+        rule = "PathPrefix:/jet"
+'
+    }
+
     $templates += '
 [backends]
     [backends.lucid]
@@ -128,6 +139,16 @@ logLevel = "INFO"
         weight = 10
         method="drr"
 '
+
+    if (-Not $JetExternal) {
+            $templates += '
+    [backends.jet-relay]
+        [backends.jet-relay.servers.jet-relay]
+        url = "http://devolutions-jet:7171"
+        weight = 10
+        method="drr"
+'
+    }
 
     $template = -Join $templates
 

--- a/WaykDen/Public/JetRelay.ps1
+++ b/WaykDen/Public/JetRelay.ps1
@@ -12,12 +12,12 @@ function Get-JetImage
         [string] $Platform
     )
 
-    $Version = '0.11.0'
+    $JetVersion = '0.11.0' # Update Get-WaykDenImage as well
 
     $image = if ($Platform -ne "windows") {
-        "devolutions/devolutions-jet:${Version}-buster"
+        "devolutions/devolutions-jet:${JetVersion}-buster"
     } else {
-        "devolutions/devolutions-jet:${Version}-servercore-ltsc2019"
+        "devolutions/devolutions-jet:${JetVersion}-servercore-ltsc2019"
     }
 
     return $image

--- a/WaykDen/Public/WaykDenConfig.ps1
+++ b/WaykDen/Public/WaykDenConfig.ps1
@@ -16,25 +16,25 @@ class WaykDenConfig
     [string] $DenServerUrl
     [string] $DenRouterUrl
     [string] $DenApiKey
-    [bool] $DisableTelemetry
-    [bool] $ExperimentalFeatures
-    [bool] $ServerExternal
+    [bool] $DisableTelemetry = $false
+    [bool] $ExperimentalFeatures = $false
+    [bool] $ServerExternal = $false
     [string] $ServerImage
 
     # MongoDB
     [string] $MongoUrl
     [string] $MongoVolume
-    [bool] $MongoExternal
+    [bool] $MongoExternal = $false
     [string] $MongoImage
 
     # Traefik
-    [bool] $TraefikExternal
+    [bool] $TraefikExternal = $false
     [string] $TraefikImage
 
     # Jet
     [string] $JetRelayUrl
     [int] $JetTcpPort
-    [bool] $JetExternal
+    [bool] $JetExternal = $false
     [string] $JetRelayImage
 
     # LDAP
@@ -46,12 +46,12 @@ class WaykDenConfig
     [string] $LdapServerType
     [string] $LdapBaseDn
     [string] $LdapBindType
-    [bool] $LdapCertificateValidation
+    [bool] $LdapCertificateValidation = $false
 
     # Picky
     [string] $PickyUrl
     [string] $PickyApiKey
-    [bool] $PickyExternal
+    [bool] $PickyExternal = $false
     [string] $PickyImage
 
     # Lucid
@@ -59,20 +59,20 @@ class WaykDenConfig
     [string] $LucidApiKey
     [string] $LucidAdminUsername
     [string] $LucidAdminSecret
-    [bool] $LucidExternal
+    [bool] $LucidExternal = $false
     [string] $LucidImage
 
     # NATS
     [string] $NatsUrl
     [string] $NatsUsername
     [string] $NatsPassword
-    [bool] $NatsExternal
+    [bool] $NatsExternal = $false
     [string] $NatsImage
     
     # Redis
     [string] $RedisUrl
     [string] $RedisPassword
-    [bool] $RedisExternal
+    [bool] $RedisExternal = $false
     [string] $RedisImage
 
     # Docker
@@ -487,6 +487,9 @@ function New-WaykDenConfig
 
     Expand-WaykDenConfigKeys -Config:$config
 
+    # remove default properties from object
+    $config = Remove-DefaultProperties $config $([WaykDenConfig]::new())
+
     ConvertTo-Yaml -Data (ConvertTo-SnakeCaseObject -Object $config) -OutFile $ConfigFile -Force:$Force
 
     Export-TraefikToml -ConfigPath:$ConfigPath
@@ -595,6 +598,9 @@ function Set-WaykDenConfig
     }
 
     Expand-WaykDenConfigKeys -Config:$config
+
+    # remove default properties from object
+    $config = Remove-DefaultProperties $config $([WaykDenConfig]::new())
  
     # always force overwriting wayk-den.yml when updating the config file
     ConvertTo-Yaml -Data (ConvertTo-SnakeCaseObject -Object $config) -OutFile $ConfigFile -Force
@@ -608,7 +614,8 @@ function Get-WaykDenConfig
     [OutputType('WaykDenConfig')]
     param(
         [string] $ConfigPath,
-        [switch] $Expand
+        [switch] $Expand,
+        [switch] $NonDefault
     )
 
     $ConfigPath = Find-WaykDenConfig -ConfigPath:$ConfigPath
@@ -635,6 +642,11 @@ function Get-WaykDenConfig
 
     if ($Expand) {
         Expand-WaykDenConfig $config
+    }
+
+    if ($NonDefault) {
+        # remove default properties from object
+        $config = Remove-DefaultProperties $config $([WaykDenConfig]::new())
     }
 
     return $config
@@ -672,6 +684,9 @@ function Clear-WaykDenConfig
             }
         }
     }
+
+    # remove default properties from object
+    $config = Remove-DefaultProperties $config $([WaykDenConfig]::new())
 
     # always force overwriting wayk-den.yml when updating the config file
     ConvertTo-Yaml -Data (ConvertTo-SnakeCaseObject -Object $config) -OutFile $ConfigFile -Force

--- a/WaykDen/Public/WaykDenConfig.ps1
+++ b/WaykDen/Public/WaykDenConfig.ps1
@@ -32,8 +32,9 @@ class WaykDenConfig
     [string] $TraefikImage
 
     # Jet
+    [bool] $JetExternal
     [string] $JetRelayUrl
-    [string] $JetServerUrl
+    [string] $JetRelayImage
 
     # LDAP
     [string] $LdapServerUrl
@@ -217,7 +218,6 @@ function Expand-WaykDenConfig
     $MongoVolumeDefault = "den-mongodata"
     $ServerModeDefault = "Private"
     $ListenerUrlDefault = "http://0.0.0.0:4000"
-    $JetServerUrlDefault = "api.jet-relay.net:8080"
     $JetRelayUrlDefault = "https://api.jet-relay.net"
     $PickyUrlDefault = "http://den-picky:12345"
     $LucidUrlDefault = "http://den-lucid:4242"
@@ -268,14 +268,6 @@ function Expand-WaykDenConfig
         $config.MongoVolume = $MongoVolumeDefault
     }
 
-    if (-Not $config.JetServerUrl) {
-        $config.JetServerUrl = $JetServerUrlDefault
-    }
-
-    if (-Not $config.JetRelayUrl) {
-        $config.JetRelayUrl = $JetRelayUrlDefault
-    }
-
     if (-Not $config.PickyUrl) {
         $config.PickyUrl = $PickyUrlDefault
     }
@@ -290,6 +282,16 @@ function Expand-WaykDenConfig
 
     if (-Not $config.DenRouterUrl) {
         $config.DenRouterUrl = $DenRouterUrlDefault
+    }
+
+    if (-Not $config.JetRelayUrl) {
+        if ($config.JetExternal) {
+            $config.JetRelayUrl = $JetRelayUrlDefault
+        } else {
+            if ($config.ExternalUrl) {
+                $config.JetRelayUrl = $config.ExternalUrl
+            }
+        }
     }
 
     Expand-WaykDenConfigImage -Config:$Config
@@ -395,7 +397,9 @@ function New-WaykDenConfig
         [string] $TraefikImage,
 
         # Jet
+        [bool] $JetExternal,
         [string] $JetRelayUrl,
+        [string] $JetRelayImage,
 
         # LDAP
         [string] $LdapServerUrl,
@@ -513,7 +517,9 @@ function Set-WaykDenConfig
         [string] $TraefikImage,
 
         # Jet
+        [bool] $JetExternal,
         [string] $JetRelayUrl,
+        [string] $JetRelayImage,
 
         # LDAP
         [string] $LdapServerUrl,

--- a/WaykDen/Public/WaykDenConfig.ps1
+++ b/WaykDen/Public/WaykDenConfig.ps1
@@ -32,8 +32,9 @@ class WaykDenConfig
     [string] $TraefikImage
 
     # Jet
-    [bool] $JetExternal
     [string] $JetRelayUrl
+    [int] $JetTcpPort
+    [bool] $JetExternal
     [string] $JetRelayImage
 
     # LDAP
@@ -284,13 +285,16 @@ function Expand-WaykDenConfig
         $config.DenRouterUrl = $DenRouterUrlDefault
     }
 
-    if (-Not $config.JetRelayUrl) {
-        if ($config.JetExternal) {
+    if ($config.JetExternal) {
+        if (-Not $config.JetRelayUrl) {
             $config.JetRelayUrl = $JetRelayUrlDefault
-        } else {
-            if ($config.ExternalUrl) {
-                $config.JetRelayUrl = $config.ExternalUrl
-            }
+        }
+    } else {
+        if (-Not $config.JetRelayUrl) {
+            $config.JetRelayUrl = $config.ExternalUrl
+        }
+        if (-Not $config.JetTcpPort) {
+            $config.JetTcpPort = 8080
         }
     }
 
@@ -318,7 +322,8 @@ function Export-TraefikToml()
         -LucidUrl $config.LucidUrl `
         -PickyUrl $config.PickyUrl `
         -DenRouterUrl $config.DenRouterUrl `
-        -DenServerUrl $config.DenServerUrl
+        -DenServerUrl $config.DenServerUrl `
+        -JetExternal $config.JetExternal
 
     Set-Content -Path $TraefikTomlFile -Value $TraefikToml
 }
@@ -397,8 +402,9 @@ function New-WaykDenConfig
         [string] $TraefikImage,
 
         # Jet
-        [bool] $JetExternal,
         [string] $JetRelayUrl,
+        [int] $JetTcpPort,
+        [bool] $JetExternal,
         [string] $JetRelayImage,
 
         # LDAP
@@ -517,8 +523,9 @@ function Set-WaykDenConfig
         [string] $TraefikImage,
 
         # Jet
-        [bool] $JetExternal,
         [string] $JetRelayUrl,
+        [int] $JetTcpPort,
+        [bool] $JetExternal,
         [string] $JetRelayImage,
 
         # LDAP

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -21,6 +21,8 @@ function Get-WaykDenImage
     $NatsVersion = '2.1'
     $RedisVersion = '5.0'
 
+    $JetVersion = '0.11.0' # Update Get-JetImage as well
+
     $images = if ($Platform -ne "windows") {
         [ordered]@{ # Linux containers
             "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster";
@@ -31,6 +33,8 @@ function Get-WaykDenImage
             "den-traefik" = "library/traefik:${TraefikVersion}";
             "den-nats" = "library/nats:${NatsVersion}-linux";
             "den-redis" = "library/redis:${RedisVersion}-buster";
+
+            "devolutions-jet" = "devolutions/devolutions-jet:${JetVersion}-buster";
         }
     } else {
         [ordered]@{ # Windows containers
@@ -42,6 +46,8 @@ function Get-WaykDenImage
             "den-traefik" = "library/traefik:${TraefikVersion}-windowsservercore-1809";
             "den-nats" = "library/nats:${NatsVersion}-windowsservercore-1809";
             "den-redis" = ""; # not available
+
+            "devolutions-jet" = "devolutions/devolutions-jet:${JetVersion}-servercore-ltsc2019";
         }
     }
 
@@ -71,6 +77,10 @@ function Get-WaykDenImage
 
     if ($config.RedisImage) {
         $images['den-redis'] = $config.RedisImage
+    }
+
+    if ($config.JetRelayImage) {
+        $images['devolutions-jet'] = $config.JetRelayImage
     }
 
     return $images
@@ -458,6 +468,50 @@ function Get-WaykDenService
     $DenTraefik.Command = ("--file --configFile=" + $(@($TraefikDataPath, "traefik.toml") -Join $PathSeparator))
     $DenTraefik.External = $config.TraefikExternal
     $Services += $DenTraefik
+
+    # jet relay service
+    if (-Not $config.JetExternal) {
+        $url = [System.Uri]::new($config.ExternalUrl)
+        $JetInstance = $url.Host
+        $JetWssPort = $url.Port
+        $JetTcpPort = 8080
+
+        $JetListeners = @()
+        #$JetListeners += "tcp://0.0.0.0:$JetTcpPort";
+        $JetListeners += "ws://0.0.0.0:7171,wss://<jet_instance>:$JetWssPort"
+
+        $JetRelay = [DockerService]::new()
+        $JetRelay.ContainerName = 'devolutions-jet'
+        $JetRelay.Image = $images[$JetRelay.ContainerName]
+        $JetRelay.Platform = $Platform
+        $JetRelay.Isolation = $Isolation
+        $JetRelay.RestartPolicy = $RestartPolicy
+        $JetRelay.TargetPorts = @(10256,$JetTcpPort)
+
+        foreach ($JetListener in $JetListeners) {
+            $ListenerUrl = ([string[]] $($JetListener -Split ','))[0]
+            $url = [System.Uri]::new($ListenerUrl)
+            $JetRelay.TargetPorts += @($url.Port)
+        }
+
+        $JetRelay.PublishAll = $true
+        $JetRelay.Environment = [ordered]@{
+            "JET_INSTANCE" = $JetInstance;
+            "JET_UNRESTRICTED" = "true";
+            "RUST_BACKTRACE" = "1";
+            "RUST_LOG" = "info";
+        }
+        $JetRelay.External = $false
+
+        $args = @()
+        foreach ($JetListener in $JetListeners) {
+            $args += @('-l', "`"$JetListener`"")
+        }
+
+        $JetRelay.Command = $($args -Join " ")
+
+        $Services += $JetRelay
+    }
 
     if ($config.SyslogServer) {
         foreach ($Service in $Services) {


### PR DESCRIPTION
Use a simple jet launched with Wayk Den and without requiring a separate deployment. This makes the default deployment 100% isolated from our services, instead of using our relay servers as the default option.