### PR TITLE
Add simple ListenerUrl/ExternalUrl validation

### DIFF
--- a/WaykDen/Public/WaykDenConfig.ps1
+++ b/WaykDen/Public/WaykDenConfig.ps1
@@ -301,6 +301,29 @@ function Expand-WaykDenConfig
     Expand-WaykDenConfigImage -Config:$Config
 }
 
+function Test-WaykDenConfig
+{
+    param(
+        [WaykDenConfig] $Config
+    )
+
+    if ($config.ListenerUrl) {
+        $url = [System.Uri]::new($config.ListenerUrl)
+
+        if (-Not (($url.Scheme -eq 'http') -Or ($url.Scheme -eq 'https'))) {
+            Write-Warning "Invalid ListenerUrl: $($url.OriginalString) (should begin with 'http://' or 'https://')"
+        }
+    }
+
+    if ($config.ExternalUrl) {
+        $url = [System.Uri]::new($config.ExternalUrl)
+
+        if (-Not (($url.Scheme -eq 'http') -Or ($url.Scheme -eq 'https'))) {
+            Write-Warning "Invalid ExternalUrl: $($url.OriginalString) (should begin with 'http://' or 'https://')"
+        }
+    }
+}
+
 function Export-TraefikToml()
 {
     param(

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -707,6 +707,7 @@ function Start-WaykDen
     $ConfigPath = Find-WaykDenConfig -ConfigPath:$ConfigPath
     $config = Get-WaykDenConfig -ConfigPath:$ConfigPath
     Expand-WaykDenConfig -Config $config
+    Test-WaykDenConfig -Config:$config
 
     Test-DockerHost
 


### PR DESCRIPTION
Prevent mistakes like forgetting to include 'http://' or 'https://' in the ListenerUrl and ExternalUrl parameters.