### PR TITLE
Lucid update

### DIFF
--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -13,7 +13,7 @@ function Get-WaykDenImage
 
     $Platform = $config.DockerPlatform
 
-    $LucidVersion = '3.7.2'
+    $LucidVersion = '3.9.0'
     $PickyVersion = '4.6.0'
     $ServerVersion = '2.8.0'
 
@@ -26,7 +26,7 @@ function Get-WaykDenImage
 
     $images = if ($Platform -ne "windows") {
         [ordered]@{ # Linux containers
-            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster";
+            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster-dev";
             "den-picky" = "devolutions/picky:${PickyVersion}-buster";
             "den-server" = "devolutions/den-server:${ServerVersion}-buster";
 
@@ -302,18 +302,24 @@ function Get-WaykDenService
     $DenLucid.Environment = [ordered]@{
         "LUCID_ADMIN__SECRET" = $LucidAdminSecret;
         "LUCID_ADMIN__USERNAME" = $LucidAdminUsername;
-        "LUCID_AUTHENTICATION__KEY" = $LucidApiKey;
+        "LUCID_API__KEY" = $LucidApiKey;
         "LUCID_DATABASE__URL" = $MongoUrl;
-        "LUCID_TOKEN__ISSUER" = "$ExternalUrl/lucid";
+        "LUCID_TOKEN__DEFAULT_ISSUER" = "$ExternalUrl";
+        "LUCID_TOKEN__ISSUERS" = "${ListenerScheme}://localhost:$TraefikPort";
+        "LUCID_API__ALLOWED_ORIGINS" = "$ExternalUrl";
         "LUCID_ACCOUNT__APIKEY" = $DenApiKey;
         "LUCID_ACCOUNT__LOGIN_URL" = "$DenServerUrl/account/login";
         "LUCID_ACCOUNT__REFRESH_USER_URL" = "$DenServerUrl/account/refresh";
         "LUCID_ACCOUNT__FORGOT_PASSWORD_URL" = "$DenServerUrl/account/forgot";
         "LUCID_ACCOUNT__SEND_ACTIVATION_EMAIL_URL" = "$DenServerUrl/account/activation";
         "LUCID_LOCALHOST_LISTENER" = $ListenerScheme;
+        "LUCID_LOGIN__ALLOW_UNVERIFIED_EMAIL_LOGIN" = "true";
+        "LUCID_LOGIN__PATH_PREFIX" = "lucid";
+        "LUCID_LOGIN__PASSWORD_DELEGATION" = "true"
         "LUCID_LOGIN__DEFAULT_LOCALE" = "en_US";
-        "RUST_BACKTRACE" = $RustBacktrace;
+        "RUST_BACKTRACE" = $RustBacktrace;   
     }
+
     $DenLucid.Healthcheck = [DockerHealthcheck]::new("curl -sS $LucidUrl/health")
     $DenLucid.External = $config.LucidExternal
     $Services += $DenLucid

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -14,7 +14,7 @@ function Get-WaykDenImage
     $Platform = $config.DockerPlatform
 
     $LucidVersion = '3.9.0'
-    $PickyVersion = '4.6.0'
+    $PickyVersion = '4.7.0'
     $ServerVersion = '2.11.0'
 
     $MongoVersion = '4.2'

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -15,7 +15,7 @@ function Get-WaykDenImage
 
     $LucidVersion = '3.9.0'
     $PickyVersion = '4.6.0'
-    $ServerVersion = '2.8.0'
+    $ServerVersion = '2.11.0'
 
     $MongoVersion = '4.2'
     $TraefikVersion = '1.7'
@@ -28,7 +28,7 @@ function Get-WaykDenImage
         [ordered]@{ # Linux containers
             "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster-dev";
             "den-picky" = "devolutions/picky:${PickyVersion}-buster";
-            "den-server" = "devolutions/den-server:${ServerVersion}-buster";
+            "den-server" = "devolutions/den-server:${ServerVersion}-buster-dev";
 
             "den-mongo" = "library/mongo:${MongoVersion}-bionic";
             "den-traefik" = "library/traefik:${TraefikVersion}";
@@ -39,9 +39,9 @@ function Get-WaykDenImage
         }
     } else {
         [ordered]@{ # Windows containers
-            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-servercore-ltsc2019";
+            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-servercore-ltsc2019-dev";
             "den-picky" = "devolutions/picky:${PickyVersion}-servercore-ltsc2019";
-            "den-server" = "devolutions/den-server:${ServerVersion}-servercore-ltsc2019";
+            "den-server" = "devolutions/den-server:${ServerVersion}-servercore-ltsc2019-dev";
 
             "den-mongo" = "library/mongo:${MongoVersion}-windowsservercore-1809";
             "den-traefik" = "library/traefik:${TraefikVersion}-windowsservercore-1809";

--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -309,6 +309,7 @@ function Get-WaykDenService
         "LUCID_API__ALLOWED_ORIGINS" = "$ExternalUrl";
         "LUCID_ACCOUNT__APIKEY" = $DenApiKey;
         "LUCID_ACCOUNT__LOGIN_URL" = "$DenServerUrl/account/login";
+        "LUCID_ACCOUNT__USER_EXISTS_URL" = "$DenServerUrl/account/user-exists";
         "LUCID_ACCOUNT__REFRESH_USER_URL" = "$DenServerUrl/account/refresh";
         "LUCID_ACCOUNT__FORGOT_PASSWORD_URL" = "$DenServerUrl/account/forgot";
         "LUCID_ACCOUNT__SEND_ACTIVATION_EMAIL_URL" = "$DenServerUrl/account/activation";

--- a/WaykDen/WaykDen.psd1
+++ b/WaykDen/WaykDen.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykDen.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.2.4'
+    ModuleVersion = '2020.2.5'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'
@@ -116,7 +116,7 @@
             # ReleaseNotes = ''
 
             # Prerelease string of this module
-            # Prerelease = ''
+            Prerelease = '-rc1'
 
             # Flag to indicate whether the module requires explicit user acceptance for install/update/save
             # RequireLicenseAcceptance = $false


### PR DESCRIPTION
- Update lucid image to 3.9.0-buster-dev
- Update den-server image to 2.11.0-buster-dev
- Update picky image to 4.7.0 (Could be done in a separate PR, but was easier that way. 4.7.0 contains the update to the latest saphir)

Don't merge for now, should be merged when dev images will be ready. Still some issues to fix. 