### PR TITLE
Add env. variable to launch Lucid and remove the forgot password link

### DIFF
--- a/WaykDen/Public/WaykDenService.ps1
+++ b/WaykDen/Public/WaykDenService.ps1
@@ -314,6 +314,7 @@ function Get-WaykDenService
         "LUCID_ACCOUNT__FORGOT_PASSWORD_URL" = "$DenServerUrl/account/forgot";
         "LUCID_ACCOUNT__SEND_ACTIVATION_EMAIL_URL" = "$DenServerUrl/account/activation";
         "LUCID_LOCALHOST_LISTENER" = $ListenerScheme;
+        "LUCID_LOGIN__ALLOW_FORGOT_PASSWORD" = "false";
         "LUCID_LOGIN__ALLOW_UNVERIFIED_EMAIL_LOGIN" = "true";
         "LUCID_LOGIN__PATH_PREFIX" = "lucid";
         "LUCID_LOGIN__PASSWORD_DELEGATION" = "true"

--- a/WaykDen/WaykDen.psd1
+++ b/WaykDen/WaykDen.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykDen.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.2.5'
+    ModuleVersion = '2020.2.6'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
- I also move to 2020.2.6 to prepare next release candidate

Note : Even if we add the env. variable in Lucid, it doesn't work yet since there is an issue on Lucid side. They are working on that. But that variable will be needed.